### PR TITLE
SyntaxWarning in python 3.8

### DIFF
--- a/application.py
+++ b/application.py
@@ -88,7 +88,7 @@ def signup():
 
     email = request.form.get("email")
     email_error_msg = form_check_email(email)
-    if email_error_msg is not '':
+    if email_error_msg != '':
         flash(email_error_msg, 'error')
         return render_template('signup.html', error_visibility='block', error_msg=email_error_msg)
 
@@ -194,7 +194,7 @@ def home():
         setup_database()
         channels = channel_dao.findall()
         return render_template(
-            "chatroom.html", user_id=session['user_id'], user_name=session['username'],channels=channels
+            "chatroom.html", user_id=session['user_id'], user_name=session['username'], channels=channels
         )
     else:
         if request.method == "GET":


### PR DESCRIPTION
#41 
SyntaxWarning in compiler, Python 3.8+

![flack_literal](https://user-images.githubusercontent.com/6170626/95109922-ee795900-0745-11eb-9e0e-f2d1c6963385.png)

Read more on:
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/


